### PR TITLE
feat: add wizard validations, resume support, and build setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "voz-frontend",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.3",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27",
+    "tailwindcss": "^3.3.3",
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/adapters/memoryAdapter.ts
+++ b/src/adapters/memoryAdapter.ts
@@ -1,0 +1,51 @@
+export interface MemoryAdapter {
+  get(ns: string, key: string): any | null;
+  set(ns: string, key: string, value: any): void;
+  remove(ns: string, key: string): void;
+}
+
+const memStore: Record<string, string> = {};
+
+function buildKey(ns: string, key: string) {
+  return `${ns}:${key}`;
+}
+
+export const memoryAdapter: MemoryAdapter = {
+  get(ns, key) {
+    const k = buildKey(ns, key);
+    try {
+      if (typeof localStorage !== 'undefined') {
+        const raw = localStorage.getItem(k);
+        return raw ? JSON.parse(raw) : null;
+      }
+    } catch {
+      /* noop */
+    }
+    return memStore[k] ? JSON.parse(memStore[k]) : null;
+  },
+  set(ns, key, value) {
+    const k = buildKey(ns, key);
+    const serialized = JSON.stringify(value);
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(k, serialized);
+        return;
+      }
+    } catch {
+      /* noop */
+    }
+    memStore[k] = serialized;
+  },
+  remove(ns, key) {
+    const k = buildKey(ns, key);
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.removeItem(k);
+        return;
+      }
+    } catch {
+      /* noop */
+    }
+    delete memStore[k];
+  }
+};

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { usePersonalization } from '../store/personalization';
+import { OnboardingWizard } from '../onboarding/OnboardingWizard';
+import { MainView } from '../main/MainView';
+
+export function App() {
+  const { state } = usePersonalization();
+  return state.isComplete ? <MainView /> : <OnboardingWizard />;
+}

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ProgressBar } from '../onboarding/components/ProgressBar';
+import { Button } from '../ui/Button';
+
+interface AppShellProps {
+  step: number;
+  total: number;
+  children: React.ReactNode;
+  onBack?: () => void;
+  onNext?: () => void;
+  nextDisabled?: boolean;
+  onSaveExit?: () => void;
+  onConfirm?: () => void;
+  confirmDisabled?: boolean;
+}
+
+export function AppShell({
+  step,
+  total,
+  children,
+  onBack,
+  onNext,
+  nextDisabled,
+  onSaveExit,
+  onConfirm,
+  confirmDisabled,
+}: AppShellProps) {
+  return (
+    <div className="flex flex-col min-h-screen">
+      <header className="p-4">Logo | Paso {step}</header>
+      <ProgressBar current={step} total={total} />
+      <main className="flex-1 p-4">{children}</main>
+      <footer className="p-4 flex gap-2 justify-end">
+        {onBack && <Button id="btn-back" onClick={onBack}>Atrás</Button>}
+        {onSaveExit && <Button id="btn-save-exit" onClick={onSaveExit}>Guardar y salir</Button>}
+        {onNext && <Button id="btn-next" onClick={onNext} disabled={nextDisabled}>Continuar</Button>}
+        {onConfirm && <Button id="btn-confirm" onClick={onConfirm} disabled={confirmDisabled}>Confirmar</Button>}
+      </footer>
+    </div>
+  );
+}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -1,0 +1,60 @@
+export interface AgentProfile {
+  id: string;
+  name: string;
+  voice: 'a' | 'b' | 'c';
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserContext {
+  role: string;
+  priorities: [string, string, string];
+  timezone: string;
+  primaryEmail: string;
+}
+
+export interface TrustCircleItem {
+  alias: string;
+  email: string;
+  tags?: string[];
+}
+
+export interface UrgencyRule {
+  id: string;
+  from: string;
+  contains: string[];
+  level: 'urgent' | 'important' | 'normal';
+  active: boolean;
+}
+
+export interface PersonalizationState {
+  agentProfile: AgentProfile;
+  user: UserContext;
+  trustCircle: TrustCircleItem[];
+  rules: UrgencyRule[];
+  isComplete: boolean;
+}
+
+export interface EmailSummary {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  summary280: string;
+  why: string;
+}
+
+export interface Card {
+  type: 'email' | 'event' | 'info' | 'error';
+  // EventCard interface not yet defined
+  data: EmailSummary | any;
+  actions: ('Resumen' | 'Urgente' | 'Agendar' | 'Abrir')[];
+  meta: { createdAt: string; source: 'gmail' | 'calendar' | 'system' };
+}
+
+export interface UIState {
+  view: 'onboarding' | 'main';
+  list: Card[];
+  listFilter: 'all' | 'urgent' | 'today';
+  listSort: 'recency' | 'importance';
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { App } from './app/App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/main/CardsList.tsx
+++ b/src/main/CardsList.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import type { Card } from 'src/contracts';
+import { EmailCard } from './EmailCard';
+
+interface CardsListProps {
+  cards: Card[];
+}
+
+export function CardsList({ cards }: CardsListProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      {cards.map(c => (
+        <EmailCard key={c.data.id} summary={c.data} />
+      ))}
+    </div>
+  );
+}

--- a/src/main/EmailCard.tsx
+++ b/src/main/EmailCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import type { EmailSummary } from 'src/contracts';
+
+interface EmailCardProps {
+  summary: EmailSummary;
+}
+
+export function EmailCard({ summary }: EmailCardProps) {
+  return (
+    <div className="border p-2">
+      {/* TODO: render email summary */}
+      {summary?.subject}
+    </div>
+  );
+}

--- a/src/main/MainView.tsx
+++ b/src/main/MainView.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { CardsList } from './CardsList';
+
+export function MainView() {
+  return (
+    <div>
+      <CardsList cards={[]} />
+    </div>
+  );
+}

--- a/src/onboarding/OnboardingWizard.tsx
+++ b/src/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useState } from 'react';
+import { AppShell } from '../app/AppShell';
+import { usePersonalization } from '../store/personalization';
+import { StepAgent } from './steps/StepAgent';
+import { StepVoice } from './steps/StepVoice';
+import { StepRolePriorities } from './steps/StepRolePriorities';
+import { StepTrustCircle } from './steps/StepTrustCircle';
+import { StepRules } from './steps/StepRules';
+
+const TOTAL_STEPS = 5;
+
+export function OnboardingWizard() {
+  const { state, save, lastStep, saveLastStep } = usePersonalization();
+  const [local, setLocal] = useState(state);
+  const [step, setStep] = useState(1);
+  const [valid, setValid] = useState(false);
+
+  useEffect(() => {
+    setLocal(state);
+  }, [state]);
+
+  useEffect(() => {
+    if (lastStep) setStep(lastStep);
+  }, [lastStep]);
+
+  const goNext = () => {
+    if (!valid) return;
+    const next = Math.min(step + 1, TOTAL_STEPS);
+    save(local);
+    setStep(next);
+    saveLastStep(next);
+    setValid(false);
+  };
+  const goBack = () => {
+    const prev = Math.max(step - 1, 1);
+    setStep(prev);
+    saveLastStep(prev);
+    setValid(false);
+  };
+  const saveExit = () => {
+    save(local);
+    saveLastStep(step);
+    // TODO: navigate out
+  };
+  const confirm = () => {
+    if (!valid) return;
+    save({ ...local, isComplete: true });
+    saveLastStep(TOTAL_STEPS);
+  };
+
+  const stepContent = () => {
+    switch (step) {
+      case 1:
+        return (
+          <StepAgent
+            value={local.agentProfile}
+            onChange={agentProfile => setLocal({ ...local, agentProfile })}
+            onValidChange={setValid}
+          />
+        );
+      case 2:
+        return (
+          <StepVoice
+            value={local.agentProfile.voice}
+            onChange={voice => setLocal({ ...local, agentProfile: { ...local.agentProfile, voice } })}
+            onValidChange={setValid}
+          />
+        );
+      case 3:
+        return (
+          <StepRolePriorities
+            user={local.user}
+            onChange={user => setLocal({ ...local, user })}
+            onValidChange={setValid}
+          />
+        );
+      case 4:
+        return (
+          <StepTrustCircle
+            items={local.trustCircle}
+            onChange={items => setLocal({ ...local, trustCircle: items })}
+            onValidChange={setValid}
+          />
+        );
+      case 5:
+        return (
+          <StepRules
+            rules={local.rules}
+            onChange={rules => setLocal({ ...local, rules })}
+            onValidChange={setValid}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <AppShell
+      step={step}
+      total={TOTAL_STEPS}
+      onBack={step > 1 ? goBack : undefined}
+      onNext={step < TOTAL_STEPS ? goNext : undefined}
+      onSaveExit={saveExit}
+      onConfirm={step === TOTAL_STEPS ? confirm : undefined}
+      nextDisabled={!valid}
+      confirmDisabled={!valid}
+    >
+      {stepContent()}
+    </AppShell>
+  );
+}

--- a/src/onboarding/components/ProgressBar.tsx
+++ b/src/onboarding/components/ProgressBar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ProgressBarProps {
+  current: number;
+  total: number;
+}
+
+export function ProgressBar({ current, total }: ProgressBarProps) {
+  const pct = (current / total) * 100;
+  return (
+    <div className="h-2 bg-gray-200">
+      <div className="h-full bg-blue-500" style={{ width: `${pct}%` }} />
+    </div>
+  );
+}

--- a/src/onboarding/steps/StepAgent.tsx
+++ b/src/onboarding/steps/StepAgent.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect } from 'react';
+import { Input } from '../../ui/Input';
+import type { AgentProfile } from 'src/contracts';
+
+interface StepAgentProps {
+  value: AgentProfile;
+  onChange: (next: AgentProfile) => void;
+  onValidChange?: (v: boolean) => void;
+}
+
+export function StepAgent({ value, onChange, onValidChange }: StepAgentProps) {
+  const error = !value.name ? 'Requerido' : value.name.length > 40 ? 'Máx. 40' : '';
+
+  useEffect(() => {
+    onValidChange?.(!error);
+  }, [error, onValidChange]);
+
+  return (
+    <div id="wiz-step-1-name" className="flex flex-col">
+      <Input
+        value={value.name}
+        onChange={e => onChange({ ...value, name: e.target.value })}
+        placeholder="Laura"
+      />
+      {error && <span data-testid="error-name">{error}</span>}
+    </div>
+  );
+}

--- a/src/onboarding/steps/StepRolePriorities.tsx
+++ b/src/onboarding/steps/StepRolePriorities.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect } from 'react';
+import { Input } from '../../ui/Input';
+import type { UserContext } from '../../contracts';
+
+interface StepRolePrioritiesProps {
+  user: UserContext;
+  onChange: (user: UserContext) => void;
+  onValidChange?: (v: boolean) => void;
+}
+
+export function StepRolePriorities({ user, onChange, onValidChange }: StepRolePrioritiesProps) {
+  const updatePriority = (idx: number, value: string) => {
+    const priorities = [...user.priorities] as [string, string, string];
+    priorities[idx] = value;
+    onChange({ ...user, priorities });
+  };
+
+  const validCount = user.priorities.filter(p => p.trim()).length;
+  const errors = user.priorities.map(p => (p.trim() ? '' : 'Requerido'));
+
+  useEffect(() => {
+    onValidChange?.(validCount === 3);
+  }, [validCount, onValidChange]);
+
+  return (
+    <div id="wiz-step-3-role" className="flex flex-col gap-2">
+      <Input value={user.role} onChange={e => onChange({ ...user, role: e.target.value })} placeholder="Rol" />
+      {user.priorities.map((p, i) => (
+        <div key={i} className="flex flex-col">
+          <Input value={p} onChange={e => updatePriority(i, e.target.value)} placeholder={`Prioridad ${i + 1}`} />
+          {errors[i] && <span data-testid={`error-priority-${i}`}>{errors[i]}</span>}
+        </div>
+      ))}
+      <span>{validCount}/3</span>
+      <Input value={user.primaryEmail} readOnly />
+      <Input value={user.timezone} readOnly />
+    </div>
+  );
+}

--- a/src/onboarding/steps/StepRules.tsx
+++ b/src/onboarding/steps/StepRules.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect } from 'react';
+import { Input } from '../../ui/Input';
+import { Button } from '../../ui/Button';
+import { Select } from '../../ui/Select';
+import type { UrgencyRule } from '../../contracts';
+
+interface StepRulesProps {
+  rules: UrgencyRule[];
+  onChange: (rules: UrgencyRule[]) => void;
+  onValidChange?: (v: boolean) => void;
+}
+
+const levels: UrgencyRule['level'][] = ['urgent', 'important', 'normal'];
+
+export function StepRules({ rules, onChange, onValidChange }: StepRulesProps) {
+  const errors = rules.map(r => (r.contains.length < 1 ? 'Agregar al menos 1 palabra' : ''));
+  const allValid = rules.every(r => r.contains.length >= 1 && levels.includes(r.level));
+
+  useEffect(() => {
+    onValidChange?.(allValid);
+  }, [allValid, onValidChange]);
+
+  const update = (idx: number, field: keyof UrgencyRule, value: any) => {
+    const next = [...rules];
+    if (field === 'contains') {
+      next[idx].contains = value.split(',').map((s: string) => s.trim()).filter(Boolean);
+    } else {
+      (next[idx] as any)[field] = value;
+    }
+    onChange(next);
+  };
+
+  const add = () =>
+    onChange([
+      ...rules,
+      { id: String(Date.now()), from: '', contains: [], level: 'normal', active: true },
+    ]);
+
+  const remove = (idx: number) => onChange(rules.filter((_, i) => i !== idx));
+
+  return (
+    <div id="wiz-step-5-rules" className="flex flex-col gap-2">
+      <p className="text-sm">Esto alimenta EmailSummary.why</p>
+      {rules.map((r, i) => (
+        <div key={r.id} className="flex flex-col gap-1">
+          <Input value={r.from} onChange={e => update(i, 'from', e.target.value)} placeholder="Remitente" />
+          <Input
+            value={r.contains.join(',')}
+            onChange={e => update(i, 'contains', e.target.value)}
+            placeholder="Palabras clave"
+          />
+          {errors[i] && <span data-testid={`error-rule-${i}`}>{errors[i]}</span>}
+          <Select value={r.level} onChange={e => update(i, 'level', e.target.value)}>
+            {levels.map(l => (
+              <option key={l} value={l}>{l}</option>
+            ))}
+          </Select>
+          <Button onClick={() => remove(i)}>Eliminar</Button>
+        </div>
+      ))}
+      <Button onClick={add}>Agregar regla</Button>
+    </div>
+  );
+}

--- a/src/onboarding/steps/StepTrustCircle.tsx
+++ b/src/onboarding/steps/StepTrustCircle.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { Input } from '../../ui/Input';
+import { Button } from '../../ui/Button';
+import type { TrustCircleItem } from '../../contracts';
+
+interface StepTrustCircleProps {
+  items: TrustCircleItem[];
+  onChange: (items: TrustCircleItem[]) => void;
+  onValidChange?: (v: boolean) => void;
+}
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function StepTrustCircle({ items, onChange, onValidChange }: StepTrustCircleProps) {
+  const [rows, setRows] = useState<TrustCircleItem[]>(items);
+
+  const aliasCounts = rows.reduce<Record<string, number>>((acc, r) => {
+    const key = r.alias.trim().toLowerCase();
+    if (key) acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+
+  const errors = rows.map(r => ({
+    alias: !r.alias.trim() ? 'Requerido' : aliasCounts[r.alias.trim().toLowerCase()] > 1 ? 'Alias duplicado' : '',
+    email: emailRegex.test(r.email) ? '' : 'Email inválido',
+  }));
+
+  const allValid = errors.every(e => !e.alias && !e.email);
+
+  useEffect(() => {
+    onValidChange?.(allValid);
+  }, [allValid, onValidChange]);
+
+  useEffect(() => {
+    onChange(rows);
+  }, [rows, onChange]);
+
+  const update = (idx: number, field: keyof TrustCircleItem, value: string) => {
+    const next = [...rows];
+    next[idx] = { ...next[idx], [field]: value };
+    setRows(next);
+  };
+
+  const add = () => setRows([...rows, { alias: '', email: '' }]);
+  const remove = (idx: number) => setRows(rows.filter((_, i) => i !== idx));
+
+  return (
+    <div id="wiz-step-4-trust" className="flex flex-col gap-2">
+      {rows.map((r, i) => (
+        <div key={i} className="flex flex-col gap-1">
+          <div className="flex gap-2">
+            <Input
+              value={r.alias}
+              onChange={e => update(i, 'alias', e.target.value)}
+              placeholder="Alias"
+            />
+            <Input
+              value={r.email}
+              onChange={e => update(i, 'email', e.target.value)}
+              placeholder="Email"
+            />
+            <Button onClick={() => remove(i)}>x</Button>
+          </div>
+          {errors[i].alias && <span data-testid={`error-alias-${i}`}>{errors[i].alias}</span>}
+          {errors[i].email && <span data-testid={`error-email-${i}`}>{errors[i].email}</span>}
+        </div>
+      ))}
+      <Button onClick={add}>Agregar</Button>
+    </div>
+  );
+}

--- a/src/onboarding/steps/StepVoice.tsx
+++ b/src/onboarding/steps/StepVoice.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+import { Select } from '../../ui/Select';
+import { Button } from '../../ui/Button';
+import type { AgentProfile } from 'src/contracts';
+
+interface StepVoiceProps {
+  value: AgentProfile['voice'];
+  onChange: (v: AgentProfile['voice']) => void;
+  onValidChange?: (v: boolean) => void;
+}
+
+export function StepVoice({ value, onChange, onValidChange }: StepVoiceProps) {
+  const error = value ? '' : 'Requerido';
+
+  useEffect(() => {
+    onValidChange?.(!error);
+  }, [error, onValidChange]);
+
+  return (
+    <div id="wiz-step-2-voice" className="flex flex-col gap-2">
+      <Select value={value} onChange={e => onChange(e.target.value as AgentProfile['voice'])}>
+        <option value="">Selecciona</option>
+        <option value="a">A</option>
+        <option value="b">B</option>
+        <option value="c">C</option>
+      </Select>
+      {error && <span data-testid="error-voice">{error}</span>}
+      <Button onClick={() => { /* TODO: preview voice */ }}>Pre-escuchar</Button>
+    </div>
+  );
+}

--- a/src/store/personalization.ts
+++ b/src/store/personalization.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { memoryAdapter } from '../adapters/memoryAdapter';
+import type { PersonalizationState } from '../contracts';
+
+const NS = 'nexusg.v1.personalization';
+const KEY = 'state';
+
+const emptyState: PersonalizationState = {
+  agentProfile: { id: '', name: '', voice: 'a', createdAt: '', updatedAt: '' },
+  user: { role: '', priorities: ['', '', ''], timezone: '', primaryEmail: '' },
+  trustCircle: [],
+  rules: [],
+  isComplete: false
+};
+
+export function usePersonalization() {
+  const [state, setState] = useState<PersonalizationState>(emptyState);
+  const [lastStep, setLastStep] = useState(0);
+
+  useEffect(() => {
+    const stored = memoryAdapter.get(NS, KEY);
+    if (stored) setState(stored);
+    const step = memoryAdapter.get(NS, 'lastStep');
+    if (typeof step === 'number') setLastStep(step);
+  }, []);
+
+  const save = (next: PersonalizationState) => {
+    setState(next);
+    memoryAdapter.set(NS, KEY, next);
+  };
+
+  const saveLastStep = (step: number) => {
+    setLastStep(step);
+    memoryAdapter.set(NS, 'lastStep', step);
+  };
+
+  return { state, save, lastStep, saveLastStep };
+}

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+import type { Card, UIState } from 'src/contracts';
+
+export function useUI() {
+  const [state, setState] = useState<UIState>({
+    view: 'onboarding',
+    list: [],
+    listFilter: 'all',
+    listSort: 'recency'
+  });
+
+  return { state, setState };
+}

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export function Button({ children, ...props }: ButtonProps) {
+  return (
+    <button {...props} className="px-4 py-2 border rounded">
+      {children}
+    </button>
+  );
+}

--- a/src/ui/Chip.tsx
+++ b/src/ui/Chip.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface ChipProps {
+  label: string;
+  onRemove?: () => void;
+}
+
+export function Chip({ label, onRemove }: ChipProps) {
+  return (
+    <span className="px-2 py-1 border inline-flex items-center gap-1">
+      {label}
+      {onRemove && <button onClick={onRemove}>x</button>}
+    </span>
+  );
+}

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export function Input(props: InputProps) {
+  return <input {...props} className="border p-2" />;
+}

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export function Modal({ open, onClose, children }: ModalProps) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-4">
+        {children}
+        <button onClick={onClose}>Cerrar</button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+export function Select({ children, ...props }: SelectProps) {
+  return (
+    <select {...props} className="border p-2">
+      {children}
+    </select>
+  );
+}

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface ToastProps {
+  message: string;
+}
+
+export function Toast({ message }: ToastProps) {
+  if (!message) return null;
+  return (
+    <div className="fixed bottom-4 right-4 p-2 bg-gray-800 text-white">
+      {message}
+    </div>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ESNext", "DOM"],
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "src/*": ["src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      src: path.resolve(__dirname, 'src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add inline validations and required checks for all onboarding wizard steps
- disable navigation until current step is valid and persist last step for resume
- track personalization lastStep in store for atomic saves
- add minimal Vite+React+TS+Tailwind tooling and bootstrap files

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(fails: AttributeError and assertion mismatches in gmail tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad036c6ca4832e82db27615ba04c0c