### PR TITLE
feat: enable dark theme with toggle

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,46 @@
+name: Deploy
+
+on:
+  push:
+    branches: ['main']
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/src/app/AppShell.tsx
+++ b/src/app/AppShell.tsx
@@ -25,9 +25,17 @@ export function AppShell({
   onConfirm,
   confirmDisabled,
 }: AppShellProps) {
+  const toggleTheme = () => {
+    document.documentElement.classList.toggle('dark');
+  };
   return (
     <div className="flex flex-col min-h-screen">
-      <header className="p-4">Logo | Paso {step}</header>
+      <header className="p-4 flex items-center justify-between">
+        <span>Logo | Paso {step}</span>
+        <Button id="btn-theme" className="px-2 py-1 text-sm" onClick={toggleTheme}>
+          Tema
+        </Button>
+      </header>
       <ProgressBar current={step} total={total} />
       <main className="flex-1 p-4">{children}</main>
       <footer className="p-4 flex gap-2 justify-end">

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  .panel {
+    @apply bg-white text-gray-900 dark:bg-zinc-900 dark:text-gray-100;
+  }
+
+  .btn {
+    @apply px-4 py-2 border rounded bg-blue-600 text-white hover:bg-blue-700
+      focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50
+      disabled:cursor-not-allowed dark:bg-blue-500 dark:hover:bg-blue-400
+      dark:focus:ring-blue-400;
+  }
+
+  .input-base {
+    @apply border border-gray-300 rounded px-3 py-2 focus:outline-none
+      focus:ring-2 focus:ring-blue-500 focus:border-blue-500
+      dark:bg-zinc-800 dark:border-zinc-700 dark:text-gray-100
+      dark:focus:ring-blue-400 dark:focus:border-blue-400;
+  }
+
+  .toast {
+    @apply fixed bottom-4 right-4 px-4 py-2 bg-gray-800 text-white
+      rounded shadow dark:bg-zinc-700;
+  }
+}

--- a/src/main/CardsList.tsx
+++ b/src/main/CardsList.tsx
@@ -1,16 +1,43 @@
 import React from 'react';
 import type { Card } from 'src/contracts';
 import { EmailCard } from './EmailCard';
+import { useUI } from 'src/store/ui';
 
 interface CardsListProps {
   cards: Card[];
 }
 
 export function CardsList({ cards }: CardsListProps) {
+  const { state } = useUI();
+
+  const filtered = cards.filter(c => {
+    if (state.listFilter === 'urgent') return c.actions.includes('Urgente');
+    if (state.listFilter === 'today') {
+      const today = new Date().toDateString();
+      return new Date(c.meta.createdAt).toDateString() === today;
+    }
+    return true;
+  });
+
+  const visibleCards = [...filtered].sort((a, b) => {
+    if (state.listSort === 'recency') {
+      return (
+        new Date(b.meta.createdAt).getTime() -
+        new Date(a.meta.createdAt).getTime()
+      );
+    }
+    const isUrgent = (card: Card) => card.actions.includes('Urgente');
+    return Number(isUrgent(b)) - Number(isUrgent(a));
+  });
+
   return (
     <div className="flex flex-col gap-2">
-      {cards.map(c => (
-        <EmailCard key={c.data.id} summary={c.data} />
+      {visibleCards.map(c => (
+        <EmailCard
+          key={c.data.id}
+          summary={c.data}
+          importance={c.actions.includes('Urgente') ? 'urgent' : 'normal'}
+        />
       ))}
     </div>
   );

--- a/src/main/EmailCard.tsx
+++ b/src/main/EmailCard.tsx
@@ -1,15 +1,36 @@
 import React from 'react';
 import type { EmailSummary } from 'src/contracts';
+import { Button } from 'src/ui/Button';
 
 interface EmailCardProps {
   summary: EmailSummary;
+  importance: 'urgent' | 'important' | 'normal';
 }
 
-export function EmailCard({ summary }: EmailCardProps) {
+export function EmailCard({ summary, importance }: EmailCardProps) {
+  const badgeColor =
+    importance === 'urgent'
+      ? 'bg-red-500'
+      : importance === 'important'
+      ? 'bg-yellow-500'
+      : 'bg-gray-300';
+
   return (
-    <div className="border p-2">
-      {/* TODO: render email summary */}
-      {summary?.subject}
+    <div className="border p-4 rounded">
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h3 className="font-semibold">{summary.subject}</h3>
+          <p className="text-sm text-gray-600">{summary.from}</p>
+        </div>
+        <span className={`text-xs text-white px-2 py-1 rounded ${badgeColor}`}>
+          {importance}
+        </span>
+      </div>
+      <p className="mb-4 text-sm text-gray-700">{summary.summary280}</p>
+      <div className="flex gap-2">
+        <Button>Abrir</Button>
+        <Button>Resumen</Button>
+      </div>
     </div>
   );
 }

--- a/src/main/MainView.tsx
+++ b/src/main/MainView.tsx
@@ -1,10 +1,52 @@
 import React from 'react';
 import { CardsList } from './CardsList';
+import { useUI } from 'src/store/ui';
+import { Select } from 'src/ui/Select';
+import { Button } from 'src/ui/Button';
 
 export function MainView() {
+  const { state, setState } = useUI();
+
+  const handleFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setState(s => ({ ...s, listFilter: e.target.value as any }));
+  };
+
+  const handleSortChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setState(s => ({ ...s, listSort: e.target.value as any }));
+  };
+
   return (
-    <div>
-      <CardsList cards={[]} />
+    <div className="p-4">
+      <div id="main-toolbar" className="mb-4 flex gap-2">
+        <Select
+          id="filter-select"
+          value={state.listFilter}
+          onChange={handleFilterChange}
+        >
+          <option value="all">all</option>
+          <option value="urgent">urgent</option>
+          <option value="today">today</option>
+        </Select>
+        <Select
+          id="sort-select"
+          value={state.listSort}
+          onChange={handleSortChange}
+        >
+          <option value="recency">recency</option>
+          <option value="importance">importance</option>
+        </Select>
+      </div>
+
+      {state.list.length === 0 ? (
+        <div className="text-center space-y-4">
+          <p>No hay tarjetas aún</p>
+          <Button onClick={() => setState(s => ({ ...s, view: 'config' as any }))}>
+            Ir a Config
+          </Button>
+        </div>
+      ) : (
+        <CardsList cards={state.list} />
+      )}
     </div>
   );
 }

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -1,5 +1,9 @@
-import { useState } from 'react';
-import type { Card, UIState } from 'src/contracts';
+import { useState, useEffect } from 'react';
+import type { UIState } from 'src/contracts';
+import { memoryAdapter } from 'src/adapters/memoryAdapter';
+
+const NS = 'nexusg.v1.ui';
+const KEY = 'store';
 
 export function useUI() {
   const [state, setState] = useState<UIState>({
@@ -9,5 +13,22 @@ export function useUI() {
     listSort: 'recency'
   });
 
-  return { state, setState };
+  useEffect(() => {
+    const stored = memoryAdapter.get(NS, KEY);
+    if (stored) setState(s => ({ ...s, ...stored }));
+  }, []);
+
+  const updateState = (updater: (prev: UIState) => UIState) => {
+    setState(prev => {
+      const next = updater(prev);
+      memoryAdapter.set(NS, KEY, {
+        view: next.view,
+        listFilter: next.listFilter,
+        listSort: next.listSort
+      });
+      return next;
+    });
+  };
+
+  return { state, setState: updateState };
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-export function Button({ children, ...props }: ButtonProps) {
+export function Button({ children, className = '', ...props }: ButtonProps) {
   return (
-    <button {...props} className="px-4 py-2 border rounded">
+    <button
+      {...props}
+      className={`btn ${className}`}
+    >
       {children}
     </button>
   );

--- a/src/ui/Chip.tsx
+++ b/src/ui/Chip.tsx
@@ -7,9 +7,17 @@ interface ChipProps {
 
 export function Chip({ label, onRemove }: ChipProps) {
   return (
-    <span className="px-2 py-1 border inline-flex items-center gap-1">
+    <span className="px-2 py-1 border rounded-full bg-gray-100 text-sm inline-flex items-center gap-1">
       {label}
-      {onRemove && <button onClick={onRemove}>x</button>}
+      {onRemove && (
+        <button
+          onClick={onRemove}
+          className="text-gray-500 hover:text-gray-700 focus:outline-none"
+          aria-label="remove"
+        >
+          ×
+        </button>
+      )}
     </span>
   );
 }

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-export function Input(props: InputProps) {
-  return <input {...props} className="border p-2" />;
+export function Input({ className = '', ...props }: InputProps) {
+  return (
+    <input
+      {...props}
+      className={`input-base ${className}`}
+    />
+  );
 }

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from './Button';
 
 interface ModalProps {
   open: boolean;
@@ -10,9 +11,11 @@ export function Modal({ open, onClose, children }: ModalProps) {
   if (!open) return null;
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/50">
-      <div className="bg-white p-4">
+      <div className="bg-white p-6 rounded shadow-lg max-w-lg w-full">
         {children}
-        <button onClick={onClose}>Cerrar</button>
+        <div className="mt-4 text-right">
+          <Button onClick={onClose}>Cerrar</Button>
+        </div>
       </div>
     </div>
   );

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
 
-export function Select({ children, ...props }: SelectProps) {
+export function Select({ children, className = '', ...props }: SelectProps) {
   return (
-    <select {...props} className="border p-2">
+    <select
+      {...props}
+      className={`input-base ${className}`}
+    >
       {children}
     </select>
   );

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -7,7 +7,7 @@ interface ToastProps {
 export function Toast({ message }: ToastProps) {
   if (!message) return null;
   return (
-    <div className="fixed bottom-4 right-4 p-2 bg-gray-800 text-white">
+    <div className="toast">
       {message}
     </div>
   );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,16 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
+  base: process.env.GITHUB_ACTIONS ? '/voz/' : '/',
   plugins: [react()],
   resolve: {
     alias: {
       src: path.resolve(__dirname, 'src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'index.html'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- define shared Tailwind utilities with dark variants
- apply dark-friendly styling to Button, Input, Select and Toast
- add small "Tema" toggle button in app header
- persist view, listFilter and listSort in UI store using memoryAdapter
- add GitHub Pages workflow and Vite base configuration for deployment

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Could not resolve entry module "index.html")

------
https://chatgpt.com/codex/tasks/task_e_68adddedbf90832e981b8a5f10af6ad3