### PR TITLE
feat: introduce design tokens and refactor ui components

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,17 +1,42 @@
-@'
 <!doctype html>
 <html lang="es">
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Voz</title>
-</head>
-
-<body>
+    <style>
+      :root {
+        --bg: #ffffff;
+        --bg-muted: #f1f5f9;
+        --card: #ffffff;
+        --border: #e2e8f0;
+        --ring: #3b82f6;
+        --fg: #0f172a;
+        --fg-muted: #475569;
+        --primary: #3b82f6;
+        --primary-fg: #ffffff;
+        --success: #16a34a;
+        --warning: #d97706;
+        --danger: #dc2626;
+      }
+      .dark {
+        --bg: #0f172a;
+        --bg-muted: #1e293b;
+        --card: #1e293b;
+        --border: #334155;
+        --ring: #3b82f6;
+        --fg: #f1f5f9;
+        --fg-muted: #94a3b8;
+        --primary: #3b82f6;
+        --primary-fg: #ffffff;
+        --success: #22c55e;
+        --warning: #f59e0b;
+        --danger: #ef4444;
+      }
+    </style>
+  </head>
+  <body class="bg-[--bg] text-[--fg]">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  </body>
 </html>
-'@ | Set-Content -Encoding UTF8 index.html

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:gh": "vite build && node -e \"const fs=require('fs');fs.copyFileSync('dist/index.html','dist/404.html')\"",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -3,9 +3,12 @@ import { useUI } from "../store/ui";
 import { TopNav } from "./TopNav";
 import { MainView } from "../main/MainView";
 import { ConfigPage } from "../settings/ConfigPage";
+import { ToastContainer } from "../ui/Toast";
+import { useToast } from "../ui/useToast";
 
 export function App() {
   const { state: ui } = useUI();
+  const toast = useToast();
 
   // Vista: 'config' o 'main' (no hay wizard)
   const body = ui.view === "config" ? <ConfigPage /> : <MainView />;
@@ -16,6 +19,7 @@ export function App() {
       <div className="mx-auto w-full max-w-5xl p-4">
         {body}
       </div>
+      <ToastContainer toasts={toast.toasts} />
     </div>
   );
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-type Variant = "primary" | "secondary" | "ghost";
-type Size = "sm" | "md";
+type Variant = "primary" | "secondary" | "danger" | "ghost";
+type Size = "sm" | "md" | "lg";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
@@ -9,30 +9,29 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
 }
 
 const base =
-  "inline-flex items-center justify-center rounded-md font-medium border transition-colors " +
-  "disabled:opacity-50 disabled:cursor-not-allowed";
+  "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring] disabled:opacity-60 disabled:pointer-events-none";
 
 const variants: Record<Variant, string> = {
   primary:
-    "border-blue-600 bg-blue-600 text-white hover:bg-blue-700 hover:border-blue-700 " +
-    "dark:border-blue-500 dark:bg-blue-500 dark:hover:bg-blue-600",
+    "bg-[--primary] text-[--primary-fg] border border-[--primary] hover:opacity-90",
   secondary:
-    "border-gray-300 bg-white text-gray-900 hover:bg-gray-100 " +
-    "dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:bg-zinc-800",
+    "bg-[--bg-muted] text-[--fg] border border-[--border] hover:bg-[--bg]",
+  danger:
+    "bg-[--danger] text-[--primary-fg] border border-[--danger] hover:opacity-90",
   ghost:
-    "border-transparent bg-transparent text-gray-700 hover:bg-gray-100 " +
-    "dark:text-zinc-200 dark:hover:bg-zinc-800",
+    "bg-transparent text-[--fg] border border-transparent hover:bg-[--bg-muted]",
 };
 
 const sizes: Record<Size, string> = {
-  sm: "px-2 py-1 text-sm",
-  md: "px-3 py-2 text-sm",
+  sm: "h-8 px-3 text-sm",
+  md: "h-10 px-4 text-sm",
+  lg: "h-12 px-6 text-base",
 };
 
 export function Button({
   variant = "secondary",
   size = "md",
-  className,
+  className = "",
   ...props
 }: ButtonProps) {
   const cls = [base, variants[variant], sizes[size], className]

--- a/src/ui/ConfirmModal.tsx
+++ b/src/ui/ConfirmModal.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useId, useRef } from "react";
+import { Button } from "./Button";
+
+export type ConfirmModalProps = {
+  open: boolean;
+  title?: string;              // default: "Hay cambios sin guardar"
+  description?: string;        // default breve
+  confirmLabel?: string;       // default: "Guardar y continuar"
+  discardLabel?: string;       // default: "Descartar cambios"
+  cancelLabel?: string;        // default: "Cancelar"
+  onConfirm: () => void;       // guardar
+  onDiscard: () => void;       // descartar
+  onCancel: () => void;        // cerrar sin acción
+};
+
+export function ConfirmModal({
+  open,
+  title = "Hay cambios sin guardar",
+  description = "Los cambios se perderán si sales sin guardar.",
+  confirmLabel = "Guardar y continuar",
+  discardLabel = "Descartar cambios",
+  cancelLabel = "Cancelar",
+  onConfirm,
+  onDiscard,
+  onCancel,
+}: ConfirmModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  const descId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+    const focusable = panel.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === "Tab") {
+        if (focusable.length === 0) return;
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            (last as HTMLElement)?.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            (first as HTMLElement)?.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    (first as HTMLElement)?.focus();
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      <div
+        ref={panelRef}
+        className="w-full max-w-sm rounded-md bg-[--card] p-6 shadow-lg"
+      >
+        <h2 id={titleId} className="mb-2 text-lg font-semibold text-[--fg]">
+          {title}
+        </h2>
+        <p id={descId} className="mb-4 text-sm text-[--fg-muted]">
+          {description}
+        </p>
+        <div className="flex justify-end gap-2">
+          <Button variant="primary" onClick={onConfirm}>
+            {confirmLabel}
+          </Button>
+          <Button variant="danger" onClick={onDiscard}>
+            {discardLabel}
+          </Button>
+          <Button variant="secondary" onClick={onCancel}>
+            {cancelLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/Input.tsx
+++ b/src/ui/Input.tsx
@@ -6,7 +6,7 @@ export function Input({ className = '', ...props }: InputProps) {
   return (
     <input
       {...props}
-      className={`input-base ${className}`}
+      className={`h-10 w-full rounded-md border border-[--border] bg-[--card] px-3 text-sm text-[--fg] placeholder:text-[--fg-muted] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring] aria-[invalid=true]:border-[--danger] disabled:opacity-60 ${className}`}
     />
   );
 }

--- a/src/ui/Select.tsx
+++ b/src/ui/Select.tsx
@@ -6,7 +6,7 @@ export function Select({ children, className = '', ...props }: SelectProps) {
   return (
     <select
       {...props}
-      className={`input-base ${className}`}
+      className={`h-10 w-full rounded-md border border-[--border] bg-[--card] px-3 text-sm text-[--fg] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring] aria-[invalid=true]:border-[--danger] disabled:opacity-60 ${className}`}
     >
       {children}
     </select>

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -1,25 +1,71 @@
-import React from "react";
+import React, { useEffect, useState, useCallback } from "react";
 
-export interface ToastProps {
+export type ToastType = "success" | "error" | "info";
+
+export type ToastProps = {
+  id: string;
+  type: ToastType;
   message: string;
-  kind?: "success" | "error" | "info";
-}
-
-const kinds: Record<NonNullable<ToastProps["kind"]>, string> = {
-  success: "bg-green-600",
-  error: "bg-red-600",
-  info: "bg-gray-800",
+  onClose: (id: string) => void;
+  durationMs?: number;
 };
 
-export function Toast({ message, kind = "info" }: ToastProps) {
-  if (!message) return null;
+const typeStyles: Record<ToastType, string> = {
+  success: "border-l-[--success]",
+  error: "border-l-[--danger]",
+  info: "border-l-[--ring]",
+};
+
+export function Toast({ id, type, message, onClose, durationMs }: ToastProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 10);
+    const d = setTimeout(() => handleClose(), durationMs ?? 5000);
+    return () => {
+      clearTimeout(t);
+      clearTimeout(d);
+    };
+  }, [durationMs]);
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+    setTimeout(() => onClose(id), 200);
+  }, [id, onClose]);
+
+  const role = type === "error" ? "alert" : "status";
+
   return (
     <div
-      className={`fixed bottom-4 right-4 z-50 rounded-md px-3 py-2 text-white shadow-lg ${kinds[kind]}`}
-      role="status"
-      aria-live="polite"
+      role={role}
+      className={`pointer-events-auto mb-2 flex items-start gap-2 rounded-md border border-[--border] ${typeStyles[type]} border-l-4 bg-[--card] px-4 py-3 text-sm text-[--fg] shadow transition transform duration-200 ${visible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"}`}
     >
-      {message}
+      <span className="flex-1">{message}</span>
+      <button
+        type="button"
+        aria-label="Cerrar"
+        onClick={handleClose}
+        className="ml-2 text-[--fg-muted] hover:text-[--fg]"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export interface ToastContainerProps {
+  toasts: ToastProps[];
+}
+
+export function ToastContainer({ toasts }: ToastContainerProps) {
+  return (
+    <div
+      aria-live="polite"
+      className="fixed top-4 right-4 z-50 flex flex-col"
+    >
+      {toasts.map((t) => (
+        <Toast key={t.id} {...t} />
+      ))}
     </div>
   );
 }

--- a/src/ui/useToast.ts
+++ b/src/ui/useToast.ts
@@ -1,0 +1,24 @@
+import { useCallback, useState } from "react";
+import { ToastProps, ToastType } from "./Toast";
+
+function generateId() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function useToast() {
+  const [toasts, setToasts] = useState<ToastProps[]>([]);
+
+  const remove = useCallback((id: string) => {
+    setToasts((ts) => ts.filter((t) => t.id !== id));
+  }, []);
+
+  const push = useCallback(
+    (type: ToastType, message: string, durationMs?: number) => {
+      const id = generateId();
+      setToasts((ts) => [...ts, { id, type, message, onClose: remove, durationMs }]);
+    },
+    [remove]
+  );
+
+  return { toasts, push, remove };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  base: process.env.GITHUB_ACTIONS ? '/voz/' : '/',
+  base: '/voz/',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- define light/dark CSS color tokens
- refactor Input, Select and Button to use tokens and accessible states
- add accessible toast notifications with hook and container
- add reusable ConfirmModal component for unsaved changes
- configure Vite base path and 404 fallback for GitHub Pages

## Testing
- `npm run build`
- `npm run build:gh`


------
https://chatgpt.com/codex/tasks/task_e_68ae83fed290832eaf197c32c348aa1d