### PR TITLE
feat(app): add main view and UI states

### DIFF
--- a/src/app/MainView.tsx
+++ b/src/app/MainView.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { SidebarNav, NavItem } from '../ui/SidebarNav';
+import { FiltersBar, Filters } from '../ui/FiltersBar';
+import { CardsList, CardProps } from '../ui/CardsList';
+import { EmptyState } from '../ui/EmptyState';
+import { SkeletonList } from '../ui/SkeletonList';
+
+export type MainViewProps = {
+  nav: { items: NavItem[]; activeId?: string; onSelect: (id: string) => void };
+  filters: { value: Filters; onChange: (f: Filters) => void; tags?: string[] };
+  data: {
+    items: CardProps[];
+    loading: boolean;
+    page: number;
+    pageSize: number;
+    total?: number;               // opcional para mostrar contador
+    onPage: (page: number) => void;
+    onOpen?: (id: string) => void;
+  };
+  title?: string;                 // default: "Bandeja"
+  emptyHint?: string;             // mensaje para estado vacío
+};
+
+export function MainView({ nav, filters, data, title = 'Bandeja', emptyHint }: MainViewProps): JSX.Element {
+  const titleId = React.useId();
+  const count = data.total ?? data.items.length;
+  const prevDisabled = data.page <= 1;
+  const nextDisabled = data.items.length < data.pageSize;
+
+  return (
+    <div className="grid md:grid-cols-[240px_1fr] gap-4">
+      <nav aria-label="Navegación" className="md:sticky md:top-0 md:h-screen">
+        <SidebarNav items={nav.items} activeId={nav.activeId} onSelect={nav.onSelect} />
+      </nav>
+      <main role="main" className="flex flex-col gap-4 bg-[--bg]">
+        <div className="sticky top-0 z-10 bg-[--bg] border-b border-[--border] p-4">
+          <header aria-labelledby={titleId} className="flex items-center justify-between">
+            <div className="flex items-baseline gap-2">
+              <h1 id={titleId} className="text-lg font-semibold text-[--fg]">{title}</h1>
+              <span className="text-sm text-[--fg-muted]">{count} resultados</span>
+            </div>
+            <div className="flex items-center gap-2" />
+          </header>
+          <div className="mt-2">
+            <FiltersBar value={filters.value} onChange={filters.onChange} tags={filters.tags} />
+          </div>
+        </div>
+        <div className="p-4">
+          {data.loading ? (
+            <SkeletonList />
+          ) : data.items.length === 0 ? (
+            <EmptyState message={emptyHint || 'Sin resultados'} />
+          ) : (
+            <CardsList items={data.items} onOpen={data.onOpen} />
+          )}
+        </div>
+        <nav aria-label="Paginación" className="px-4 pb-4 flex justify-center gap-2">
+          <button
+            type="button"
+            aria-label="Anterior"
+            disabled={prevDisabled}
+            onClick={() => data.onPage(data.page - 1)}
+            className="rounded-md border border-[--border] bg-[--card] px-3 py-1 text-sm text-[--fg] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-[--ring]"
+          >
+            Anterior
+          </button>
+          <button
+            type="button"
+            aria-label="Siguiente"
+            disabled={nextDisabled}
+            onClick={() => data.onPage(data.page + 1)}
+            className="rounded-md border border-[--border] bg-[--card] px-3 py-1 text-sm text-[--fg] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-[--ring]"
+          >
+            Siguiente
+          </button>
+        </nav>
+      </main>
+    </div>
+  );
+}
+

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export type CardProps = {
+  id: string;
+  title: string;
+  subtitle?: string;
+  preview?: string; // truncado visual a ~3 líneas
+  meta?: { date?: string; tags?: string[]; urgent?: boolean };
+  onOpen?: (id: string) => void;
+};
+
+export function Card({ id, title, subtitle, preview, meta, onOpen }: CardProps): JSX.Element {
+  const titleId = `${id}-title`;
+  return (
+    <article
+      aria-labelledby={titleId}
+      className="relative rounded-2xl border bg-[--card] border-[--border] p-4 shadow-sm hover:shadow-md transition"
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex min-w-0 flex-col flex-1">
+          <h3 id={titleId} className="text-base font-semibold text-[--fg]">
+            {title}
+          </h3>
+          {subtitle && <p className="text-xs text-[--fg-muted]">{subtitle}</p>}
+        </div>
+        {meta?.urgent && (
+          <span className="ml-2 shrink-0 rounded-full border border-[--danger] bg-[--danger] px-2 py-0.5 text-xs text-[--bg]">
+            Urgente
+          </span>
+        )}
+      </div>
+      {preview && (
+        <p className="mt-2 overflow-hidden [display:-webkit-box] [-webkit-line-clamp:3] [-webkit-box-orient:vertical] text-sm text-[--fg]">
+          {preview}
+        </p>
+      )}
+      {(meta?.tags || meta?.date) && (
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {meta?.tags?.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-[--bg-muted] px-2 py-0.5 text-xs text-[--fg]"
+            >
+              {tag}
+            </span>
+          ))}
+          {meta?.date && (
+            <span className="ml-auto text-xs text-[--fg-muted]">{meta.date}</span>
+          )}
+        </div>
+      )}
+      {onOpen && (
+        <button
+          type="button"
+          onClick={() => onOpen(id)}
+          aria-label={`Abrir ${title}`}
+          className="absolute inset-0 rounded-2xl focus:outline-none focus:ring-2 focus:ring-[--ring]"
+        />
+      )}
+    </article>
+  );
+}
+

--- a/src/ui/CardsList.tsx
+++ b/src/ui/CardsList.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import type { CardProps } from './Card';
+import { Card } from './Card';
+
+export type CardsListProps = {
+  items: CardProps[];
+  onOpen?: (id: string) => void;
+  emptyHint?: string; // mensaje opcional si no hay items
+};
+
+export function CardsList({ items, onOpen, emptyHint }: CardsListProps): JSX.Element {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+
+  if (items.length === 0) {
+    return (
+      <div className="p-8 text-center text-sm text-[--fg-muted]">
+        {emptyHint || 'Sin resultados'}
+      </div>
+    );
+  }
+
+  return (
+    <ul role="list" className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {items.map((item) => (
+        <li
+          key={item.id}
+          role="listitem"
+          className={`transition-opacity transition-transform duration-200 ${
+            mounted ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
+          }`}
+        >
+          <Card {...item} onOpen={onOpen ?? item.onOpen} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/ui/EmptyState.tsx
+++ b/src/ui/EmptyState.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+type Props = { message: string };
+
+export function EmptyState({ message }: Props): JSX.Element {
+  return (
+    <div className="p-8 text-center text-sm text-[--fg-muted]">{message}</div>
+  );
+}
+

--- a/src/ui/FiltersBar.tsx
+++ b/src/ui/FiltersBar.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Input } from './Input';
+import { Select } from './Select';
+
+export type Filters = {
+  q: string;
+  urgentOnly: boolean;
+  tag?: string;
+  dateFrom?: string; // ISO yyyy-mm-dd
+  dateTo?: string;   // ISO yyyy-mm-dd
+};
+
+type Props = {
+  value: Filters;
+  onChange: (f: Filters) => void;
+  tags?: string[]; // opciones para el select de tags
+};
+
+export function FiltersBar({ value, onChange, tags = [] }: Props): JSX.Element {
+  const searchId = React.useId();
+
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      const isTyping =
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable;
+      if (e.key === '/' && !isTyping) {
+        e.preventDefault();
+        (document.getElementById(searchId) as HTMLInputElement | null)?.focus();
+      } else if (e.key === 'Escape' && value.q) {
+        onChange({ ...value, q: '' });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [searchId, value, onChange]);
+
+  const update = (patch: Partial<Filters>) => onChange({ ...value, ...patch });
+
+  return (
+    <div role="search" className="flex flex-wrap items-end gap-2">
+      <Input
+        id={searchId}
+        aria-label="Buscar"
+        placeholder="Buscar"
+        value={value.q}
+        onChange={(e) => update({ q: e.target.value })}
+        className="flex-1 min-w-[200px]"
+      />
+      <Select
+        aria-label="Etiqueta"
+        value={value.tag ?? ''}
+        onChange={(e) => update({ tag: e.target.value || undefined })}
+        className="w-40"
+      >
+        <option value="">Todas</option>
+        {tags.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </Select>
+      <label className="flex items-center gap-2 text-sm text-[--fg]">
+        <input
+          type="checkbox"
+          checked={value.urgentOnly}
+          onChange={(e) => update({ urgentOnly: e.target.checked })}
+          aria-label="Sólo urgentes"
+          className="h-4 w-4 rounded border border-[--border] bg-[--card] text-[--ring] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring]"
+        />
+        <span>Sólo urgentes</span>
+      </label>
+      <Input
+        type="date"
+        aria-label="Desde"
+        value={value.dateFrom ?? ''}
+        onChange={(e) => update({ dateFrom: e.target.value || undefined })}
+        className="w-36"
+      />
+      <Input
+        type="date"
+        aria-label="Hasta"
+        value={value.dateTo ?? ''}
+        onChange={(e) => update({ dateTo: e.target.value || undefined })}
+        className="w-36"
+      />
+    </div>
+  );
+}
+

--- a/src/ui/SidebarNav.tsx
+++ b/src/ui/SidebarNav.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export type NavItem = { id: string; label: string; icon?: JSX.Element; group?: string };
+type Props = { items: NavItem[]; activeId?: string; onSelect: (id: string) => void };
+
+export function SidebarNav({ items, activeId, onSelect }: Props) {
+  const groups = React.useMemo(() => {
+    const map = new Map<string | undefined, NavItem[]>();
+    for (const item of items) {
+      const key = item.group;
+      const arr = map.get(key);
+      if (arr) arr.push(item);
+      else map.set(key, [item]);
+    }
+    return Array.from(map.entries());
+  }, [items]);
+
+  return (
+    <nav className="flex flex-col">
+      {groups.map(([group, groupItems]) => (
+        <div key={group ?? 'default'} className="flex flex-col mt-4 first:mt-0">
+          {group && (
+            <div className="px-3 py-2 text-xs text-[--fg-muted]">{group}</div>
+          )}
+          <ul className="flex flex-col">
+            {groupItems.map((item) => {
+              const active = item.id === activeId;
+              const cls = [
+                'flex w-full items-center gap-2 px-3 py-2 text-sm text-[--fg] border-l-2 border-l-transparent rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring] hover:bg-[--bg-muted]',
+                active && 'border-[--ring] bg-[--bg-muted]'
+              ]
+                .filter(Boolean)
+                .join(' ');
+              return (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(item.id)}
+                    className={cls}
+                    aria-current={active ? 'page' : undefined}
+                  >
+                    {item.icon && <span className="shrink-0">{item.icon}</span>}
+                    <span>{item.label}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </nav>
+  );
+}
+

--- a/src/ui/SkeletonList.tsx
+++ b/src/ui/SkeletonList.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export function SkeletonList(): JSX.Element {
+  return (
+    <div className="grid grid-cols-1 gap-4">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div
+          key={i}
+          className="h-24 rounded-2xl border border-[--border] bg-[--card] animate-pulse"
+        />
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add presentational MainView with sticky header, filters, card list and pagination
- include EmptyState and SkeletonList components for empty and loading displays

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0d9d1b14832e9b36e46826a14247