### PR TITLE
feat(main-ui): add summary today panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ coverage.xml
 # === Node / Vite (frontend) ===
 node_modules/
 dist/
+!/packages/ui/dist/
+/packages/ui/dist/*
+!/packages/ui/dist/styles.css
 .vite/
 *.tsbuildinfo
 

--- a/apps/main-ui/README.md
+++ b/apps/main-ui/README.md
@@ -7,6 +7,12 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Banner y panel de resumen
+
+- Forzar la aparición del banner con `?state=firstVictory` en la URL.
+- El CTA "Ver resumen de hoy" abre un panel mock con datos de ejemplo.
+- El panel se cierra con **ESC** o con el botón "Cerrar". El foco inicial queda en ese botón y el tabulador cicla entre las acciones. Se usan `role="dialog"`, `aria-modal="true"` y `aria-label` para accesibilidad.
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/apps/main-ui/src/App.tsx
+++ b/apps/main-ui/src/App.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react';
 import FirstVictoryBanner from './components/FirstVictoryBanner';
+import SummaryTodayPanel from './components/SummaryTodayPanel';
 
 export default function App() {
+  const [summaryOpen, setSummaryOpen] = useState(false);
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-white text-text">
       <div className="mx-4 w-full max-w-xl">
-        <FirstVictoryBanner />
+        <FirstVictoryBanner onOpenSummary={() => setSummaryOpen(true)} />
 
         <div className="bg-surface backdrop-blur-[14px] rounded-2xl shadow-glass border border-white/40 p-6">
           <h1 className="text-2xl font-semibold mb-2">NexusG UI — Smoke</h1>
@@ -20,6 +24,7 @@ export default function App() {
           </div>
         </div>
       </div>
+      {summaryOpen && <SummaryTodayPanel onClose={() => setSummaryOpen(false)} />}
     </div>
   );
 }

--- a/apps/main-ui/src/components/FirstVictoryBanner.tsx
+++ b/apps/main-ui/src/components/FirstVictoryBanner.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from 'react';
 
-export default function FirstVictoryBanner() {
+interface Props {
+  onOpenSummary?: () => void;
+}
+
+export default function FirstVictoryBanner({ onOpenSummary }: Props) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
@@ -23,7 +27,8 @@ export default function FirstVictoryBanner() {
   };
 
   const onCta = () => {
-    console.log('cta:first-victory'); // TODO: conectar con resumen real en un pitch posterior
+    if (onOpenSummary) onOpenSummary();
+    else console.log('cta:first-victory'); // TODO: conectar con resumen real en un pitch posterior
   };
 
   if (!visible) return null;

--- a/apps/main-ui/src/components/SummaryTodayPanel.tsx
+++ b/apps/main-ui/src/components/SummaryTodayPanel.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  onClose: () => void;
+}
+
+export default function SummaryTodayPanel({ onClose }: Props) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const detailRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose();
+    } else if (e.key === 'Tab') {
+      if (e.shiftKey) {
+        if (document.activeElement === closeRef.current) {
+          e.preventDefault();
+          detailRef.current?.focus();
+        }
+      } else {
+        if (document.activeElement === detailRef.current) {
+          e.preventDefault();
+          closeRef.current?.focus();
+        }
+      }
+    }
+  };
+
+  const today = new Date().toLocaleDateString();
+
+  const items = [
+    { time: '09:00', subject: 'Reunión con equipo' },
+    { time: '11:30', subject: 'Llamada a proveedor' },
+    { time: '14:00', subject: 'Evento del día' },
+  ];
+
+  return (
+    <div
+      className="fixed inset-0 z-20 flex items-center justify-center bg-black/20"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Resumen de hoy"
+      onKeyDown={onKeyDown}
+    >
+      <div className="bg-surface backdrop-blur-[14px] rounded-2xl shadow-glass border border-white/40 p-4 w-full max-w-md">
+        <div className="flex items-start justify-between mb-4">
+          <h2 className="font-semibold text-lg">Resumen de hoy — {today}</h2>
+          <button
+            ref={closeRef}
+            onClick={onClose}
+            aria-label="Cerrar"
+            className="px-2 py-1 rounded-xl border border-white/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/40"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex gap-2 mb-4">
+          <span className="px-2 py-1 rounded-xl bg-primary/10 text-primary text-sm">Nuevos: 12</span>
+          <span className="px-2 py-1 rounded-xl bg-primary text-white text-sm">Urgentes: 3</span>
+          <span className="px-2 py-1 rounded-xl bg-primary/10 text-primary text-sm">Eventos: 2</span>
+        </div>
+
+        <ul className="text-sm space-y-2 mb-4">
+          {items.map((item, idx) => (
+            <li key={idx}>
+              {item.time} — {item.subject}
+            </li>
+          ))}
+        </ul>
+
+        <button
+          ref={detailRef}
+          onClick={() => console.log('cta:open-summary-detail')}
+          className="px-3 py-2 rounded-xl border border-white/40 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/40"
+        >
+          Abrir en detalle
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/packages/ui/dist/styles.css
+++ b/packages/ui/dist/styles.css
@@ -1,0 +1,8 @@
+:root {
+  --nx-color-surface: #ffffff;
+  --nx-color-primary: #2563eb;
+  --nx-color-text: #000000;
+  --nx-radius-xl: 0.75rem;
+  --nx-radius-2xl: 1rem;
+  --nx-shadow-glass: 0 4px 16px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- add modal SummaryTodayPanel with mock content and accessibility
- wire FirstVictoryBanner CTA via onOpenSummary prop
- document banner and panel usage in README

## Testing
- `npm run -w apps/main-ui build`
- `npx -w apps/main-ui tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1cedd22fc832eb7585de0d22d5815