### PR TITLE
figma→ui: tokens y Nx components

### DIFF
--- a/apps/main-ui/src/ExampleNx.tsx
+++ b/apps/main-ui/src/ExampleNx.tsx
@@ -1,0 +1,12 @@
+import { NxButton, NxChip, NxUserBubble, NxAssistantBubble } from '@nexusg/ui';
+
+export default function ExampleNx() {
+  return (
+    <div className="space-y-4 p-4">
+      <NxButton>Enviar</NxButton>
+      <NxChip>Etiqueta</NxChip>
+      <NxUserBubble ariaLabel="mensaje de usuario">Hola</NxUserBubble>
+      <NxAssistantBubble ariaLabel="mensaje del asistente">¿En qué puedo ayudarte?</NxAssistantBubble>
+    </div>
+  );
+}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,37 @@
+# @nexusg/ui
+
+UI kit con tokens y componentes básicos extraídos de Figma.
+
+## Uso
+
+1. **Estilos globales**
+
+```ts
+import '@nexusg/ui/dist/styles.css';
+```
+
+2. **Preset de Tailwind**
+
+```js
+// tailwind.config.cjs
+module.exports = {
+  presets: [require('@nexusg/ui/tailwind-preset.cjs')],
+};
+```
+
+3. **Componentes**
+
+```tsx
+import { NxButton, NxChip, NxUserBubble, NxAssistantBubble } from '@nexusg/ui';
+
+export function Example() {
+  return (
+    <div className="space-y-4">
+      <NxButton>Enviar</NxButton>
+      <NxChip>Etiqueta</NxChip>
+      <NxUserBubble ariaLabel="mensaje de usuario">Hola</NxUserBubble>
+      <NxAssistantBubble ariaLabel="mensaje del asistente">¿En qué puedo ayudarte?</NxAssistantBubble>
+    </div>
+  );
+}
+```

--- a/packages/ui/dist/styles.css
+++ b/packages/ui/dist/styles.css
@@ -1,8 +1,10 @@
 :root {
-  --nx-color-surface: #ffffff;
-  --nx-color-primary: #2563eb;
-  --nx-color-text: #000000;
-  --nx-radius-xl: 0.75rem;
-  --nx-radius-2xl: 1rem;
-  --nx-shadow-glass: 0 4px 16px rgba(0,0,0,0.1);
+  --nx-color-surface: 255 255 255;
+  --nx-color-primary: 3 2 19;
+  --nx-color-text: 29 29 29;
+  --nx-radius-xl: 0.875rem;
+  --nx-radius-2xl: 1.125rem;
+  --nx-spacing-base: 0.25rem;
+  --nx-shadow-glass: 0 4px 30px rgba(0, 0, 0, 0.1);
+  --nx-font-sans: 'Inter', 'IBM Plex Sans', sans-serif;
 }

--- a/packages/ui/src/NxAssistantBubble.tsx
+++ b/packages/ui/src/NxAssistantBubble.tsx
@@ -1,0 +1,8 @@
+import type { NxBubbleProps } from './NxUserBubble.js';
+
+export function NxAssistantBubble({ ariaLabel, className = '', ...props }: NxBubbleProps) {
+  const base = 'font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-white/40 p-[calc(var(--nx-spacing-base)*4)] self-start';
+  return (
+    <div role="group" aria-label={ariaLabel} className={`${base} ${className}`} {...props} />
+  );
+}

--- a/packages/ui/src/NxButton.tsx
+++ b/packages/ui/src/NxButton.tsx
@@ -1,0 +1,16 @@
+import type { ButtonHTMLAttributes } from 'react';
+
+export type NxButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: 'primary' | 'secondary';
+};
+
+export function NxButton({ variant = 'primary', className = '', ...props }: NxButtonProps) {
+  const base = 'font-sans inline-flex items-center justify-center rounded-xl px-[calc(var(--nx-spacing-base)*4)] py-[calc(var(--nx-spacing-base)*2)] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2';
+  const variants: Record<'primary' | 'secondary', string> = {
+    primary: 'bg-primary text-surface',
+    secondary: 'bg-surface text-primary border border-primary'
+  };
+  return (
+    <button className={`${base} ${variants[variant]} ${className}`} {...props} />
+  );
+}

--- a/packages/ui/src/NxChip.tsx
+++ b/packages/ui/src/NxChip.tsx
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from 'react';
+
+export type NxChipProps = HTMLAttributes<HTMLDivElement> & {
+  variant?: 'default' | 'urgent';
+};
+
+export function NxChip({ variant = 'default', className = '', ...props }: NxChipProps) {
+  const base = 'font-sans inline-flex items-center rounded-2xl px-[calc(var(--nx-spacing-base)*2)] py-[var(--nx-spacing-base)] focus:outline-none focus:ring-2 focus:ring-primary';
+  const variants: Record<'default' | 'urgent', string> = {
+    default: 'bg-surface text-text border border-primary',
+    urgent: 'bg-primary text-surface'
+  };
+  return (
+    <div className={`${base} ${variants[variant]} ${className}`} {...props} />
+  );
+}

--- a/packages/ui/src/NxUserBubble.tsx
+++ b/packages/ui/src/NxUserBubble.tsx
@@ -1,0 +1,12 @@
+import type { HTMLAttributes } from 'react';
+
+export interface NxBubbleProps extends HTMLAttributes<HTMLDivElement> {
+  ariaLabel: string;
+}
+
+export function NxUserBubble({ ariaLabel, className = '', ...props }: NxBubbleProps) {
+  const base = 'font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-white/40 p-[calc(var(--nx-spacing-base)*4)] self-end';
+  return (
+    <div role="group" aria-label={ariaLabel} className={`${base} ${className}`} {...props} />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,5 @@
-export {};
+export * from './tokens.js';
+export { NxButton } from './NxButton.js';
+export { NxChip } from './NxChip.js';
+export { NxUserBubble } from './NxUserBubble.js';
+export { NxAssistantBubble } from './NxAssistantBubble.js';

--- a/packages/ui/src/tokens.ts
+++ b/packages/ui/src/tokens.ts
@@ -1,0 +1,22 @@
+export const colors = {
+  surface: 'rgb(var(--nx-color-surface))',
+  primary: 'rgb(var(--nx-color-primary))',
+  text: 'rgb(var(--nx-color-text))'
+} as const;
+
+export const radii = {
+  xl: 'var(--nx-radius-xl)',
+  '2xl': 'var(--nx-radius-2xl)'
+} as const;
+
+export const spacing = {
+  base: 'var(--nx-spacing-base)'
+} as const;
+
+export const shadows = {
+  glass: 'var(--nx-shadow-glass)'
+} as const;
+
+export const fonts = {
+  sans: 'var(--nx-font-sans)'
+} as const;

--- a/packages/ui/tailwind-preset.cjs
+++ b/packages/ui/tailwind-preset.cjs
@@ -1,22 +1,26 @@
-Set-Content packages\ui\tailwind-preset.cjs @'
-/** @type {import("tailwindcss").Config} */
+/** @type {import('tailwindcss').Config} */
 module.exports = {
   theme: {
     extend: {
       colors: {
-        surface: "var(--nx-color-surface)",
-        primary: "var(--nx-color-primary)",
-        text: "var(--nx-color-text)"
+        surface: 'rgb(var(--nx-color-surface) / <alpha-value>)',
+        primary: 'rgb(var(--nx-color-primary) / <alpha-value>)',
+        text: 'rgb(var(--nx-color-text) / <alpha-value>)'
       },
       borderRadius: {
-        xl: "var(--nx-radius-xl)",
-        "2xl": "var(--nx-radius-2xl)"
+        xl: 'var(--nx-radius-xl)',
+        '2xl': 'var(--nx-radius-2xl)'
       },
       boxShadow: {
-        glass: "var(--nx-shadow-glass)"
+        glass: 'var(--nx-shadow-glass)'
+      },
+      spacing: {
+        base: 'var(--nx-spacing-base)'
+      },
+      fontFamily: {
+        sans: 'var(--nx-font-sans)'
       }
     }
   },
   plugins: []
 };
-'@


### PR DESCRIPTION
## Summary
- map figma colors, radii, spacing, shadow and fonts to CSS variables and Tailwind preset
- add accessible NxButton, NxChip, NxUserBubble and NxAssistantBubble components using tokens
- document usage of styles, preset and components; include example usage

## Testing
- `npm run -w packages/ui build`
- `npm run -w apps/main-ui build`


------
https://chatgpt.com/codex/tasks/task_e_68b1dc25dfc0832eb30f5f59f785505e