### PR TITLE
apps/main-ui hardening: consumo @nexusg/ui

### DIFF
--- a/apps/main-ui/README.md
+++ b/apps/main-ui/README.md
@@ -1,75 +1,29 @@
-# React + TypeScript + Vite
+# Main UI
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Aplicación que consume el kit `@nexusg/ui`.
 
-Currently, two official plugins are available:
+## Uso del kit
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. Importa los estilos en `src/main.tsx`:
 
-## Banner y panel de resumen
-
-- Forzar la aparición del banner con `?state=firstVictory` en la URL.
-- El CTA "Ver resumen de hoy" abre un panel mock con datos de ejemplo.
-- El panel se cierra con **ESC** o con el botón "Cerrar". El foco inicial queda en ese botón y el tabulador cicla entre las acciones. Se usan `role="dialog"`, `aria-modal="true"` y `aria-label` para accesibilidad.
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```ts
+import '@nexusg/ui/dist/styles.css';
+import './index.css';
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+2. Tailwind utiliza el preset del paquete:
 
 ```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+// tailwind.config.cjs
+module.exports = {
+  presets: [require('@nexusg/ui/tailwind-preset.cjs')],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+};
 ```
+
+## Desarrollo
+
+```bash
+npm run -w apps/main-ui dev
+```
+

--- a/apps/main-ui/src/App.tsx
+++ b/apps/main-ui/src/App.tsx
@@ -1,30 +1,45 @@
-import { useState } from 'react';
-import FirstVictoryBanner from './components/FirstVictoryBanner';
-import SummaryTodayPanel from './components/SummaryTodayPanel';
+import type { FormEvent } from 'react';
+import { NxAssistantBubble, NxButton, NxChip, NxUserBubble } from '@nexusg/ui';
 
 export default function App() {
-  const [summaryOpen, setSummaryOpen] = useState(false);
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+  };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-white text-text">
-      <div className="mx-4 w-full max-w-xl">
-        <FirstVictoryBanner onOpenSummary={() => setSummaryOpen(true)} />
-
-        <div className="bg-surface backdrop-blur-[14px] rounded-2xl shadow-glass border border-white/40 p-6">
-          <h1 className="text-2xl font-semibold mb-2">NexusG UI — Smoke</h1>
-          <p className="mb-4">Glassmorphism + tokens funcionando.</p>
-
-          <div className="flex gap-3">
-            <button className="px-4 py-2 rounded-xl bg-primary text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/60">
-              Botón primario
-            </button>
-            <button className="px-4 py-2 rounded-xl border border-black/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary/40">
-              Botón secundario
-            </button>
-          </div>
+    <div className="flex h-screen text-text">
+      <aside className="w-56 bg-surface border-r border-primary/10 p-4">
+        Sidebar
+      </aside>
+      <main className="flex flex-1 flex-col">
+        <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          <NxUserBubble ariaLabel="Mensaje de usuario">Hola</NxUserBubble>
+          <NxAssistantBubble ariaLabel="Respuesta del asistente">
+            <div className="space-y-2">
+              <p>¿En qué puedo ayudarte?</p>
+              <div className="flex gap-2">
+                <NxChip>Normal</NxChip>
+                <NxChip variant="urgent">Urgente</NxChip>
+              </div>
+            </div>
+          </NxAssistantBubble>
         </div>
-      </div>
-      {summaryOpen && <SummaryTodayPanel onClose={() => setSummaryOpen(false)} />}
+        <form
+          onSubmit={handleSubmit}
+          className="flex items-center gap-2 border-t border-primary/10 p-4"
+        >
+          <input
+            aria-label="Escribe un mensaje"
+            className="flex-1 rounded-xl border border-primary/20 bg-surface px-3 py-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            placeholder="Escribe un mensaje..."
+          />
+          <NxButton type="submit">Enviar</NxButton>
+          <NxButton type="button" variant="secondary">
+            Cancelar
+          </NxButton>
+        </form>
+      </main>
     </div>
   );
 }
+

--- a/apps/main-ui/tailwind.config.cjs
+++ b/apps/main-ui/tailwind.config.cjs
@@ -1,8 +1,6 @@
 /** @type {import('tailwindcss').Config} */
-const nxPreset = require('@nexusg/ui/tailwind-preset.cjs');
-
 module.exports = {
-  presets: [nxPreset],
+  presets: [require('@nexusg/ui/tailwind-preset.cjs')],
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- Align tailwind config to consume `@nexusg/ui` preset
- Replace demo with chat layout using `Nx` components and accessible input bar
- Document how to import kit styles, preset, and run dev server

## Testing
- `npm run -w packages/ui build`
- `npm run -w apps/main-ui build`
- `npx -w apps/main-ui tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1e2f5bbdc832e8bf97515fc7bb9f3