### PR TITLE
feat: document empty and loading debug states

### DIFF
--- a/apps/main-ui/README.md
+++ b/apps/main-ui/README.md
@@ -27,3 +27,12 @@ module.exports = {
 npm run -w apps/main-ui dev
 ```
 
+## Estados de depuración
+
+Agrega `?state=empty` o `?state=loading` al URL para forzar estados.
+
+- `?state=empty` renderiza un placeholder con `role="status"`.
+- `?state=loading` muestra skeletons con glass y `aria-busy="true"`.
+
+Revisar copy claro, contraste y que la navegación con tab mantenga foco visible en botones e inputs.
+

--- a/apps/main-ui/src/App.tsx
+++ b/apps/main-ui/src/App.tsx
@@ -1,4 +1,5 @@
 import type { FormEvent } from 'react';
+import { useMemo } from 'react';
 import { NxAssistantBubble, NxButton, NxChip, NxUserBubble } from '@nexusg/ui';
 
 export default function App() {
@@ -6,24 +7,53 @@ export default function App() {
     e.preventDefault();
   };
 
+  const state = useMemo(() => {
+    try {
+      return new URLSearchParams(window.location.search).get('state');
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const isLoading = state === 'loading';
+
+  let content;
+  if (state === 'empty') {
+    content = (
+      <div className="flex flex-1 items-center justify-center p-4" role="status">
+        <p>No hay mensajes aún.</p>
+      </div>
+    );
+  } else if (isLoading) {
+    content = (
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 animate-pulse">
+        <div className="h-4 rounded-xl bg-surface/60 backdrop-blur-[14px] shadow-glass border border-white/40" />
+        <div className="h-4 rounded-xl bg-surface/60 backdrop-blur-[14px] shadow-glass border border-white/40" />
+        <div className="h-4 rounded-xl bg-surface/60 backdrop-blur-[14px] shadow-glass border border-white/40" />
+      </div>
+    );
+  } else {
+    content = (
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        <NxUserBubble ariaLabel="Mensaje de usuario">Hola</NxUserBubble>
+        <NxAssistantBubble ariaLabel="Respuesta del asistente">
+          <div className="space-y-2">
+            <p>¿En qué puedo ayudarte?</p>
+            <div className="flex gap-2">
+              <NxChip>Normal</NxChip>
+              <NxChip variant="urgent">Urgente</NxChip>
+            </div>
+          </div>
+        </NxAssistantBubble>
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-screen text-text">
-      <aside className="w-56 bg-surface border-r border-primary/10 p-4">
-        Sidebar
-      </aside>
-      <main className="flex flex-1 flex-col">
-        <div className="flex-1 overflow-y-auto p-4 space-y-4">
-          <NxUserBubble ariaLabel="Mensaje de usuario">Hola</NxUserBubble>
-          <NxAssistantBubble ariaLabel="Respuesta del asistente">
-            <div className="space-y-2">
-              <p>¿En qué puedo ayudarte?</p>
-              <div className="flex gap-2">
-                <NxChip>Normal</NxChip>
-                <NxChip variant="urgent">Urgente</NxChip>
-              </div>
-            </div>
-          </NxAssistantBubble>
-        </div>
+      <aside className="w-56 bg-surface border-r border-primary/10 p-4">Sidebar</aside>
+      <main className="flex flex-1 flex-col" aria-busy={isLoading}>
+        {content}
         <form
           onSubmit={handleSubmit}
           className="flex items-center gap-2 border-t border-primary/10 p-4"


### PR DESCRIPTION
## Summary
- show `state` query param to render empty or loading views
- document how to debug UI states in README

## Testing
- `npm run -w apps/main-ui build`
- `npx -w apps/main-ui tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1e9983040832e89f86eee9541058b