### PR TITLE
packages/ui: hardening (tokens, preset, Nx*)

### DIFF
--- a/packages/ui/src/NxAssistantBubble.tsx
+++ b/packages/ui/src/NxAssistantBubble.tsx
@@ -1,8 +1,9 @@
 import type { NxBubbleProps } from './NxUserBubble.js';
+import { spacing } from './tokens.js';
 
 export function NxAssistantBubble({ ariaLabel, className = '', ...props }: NxBubbleProps) {
-  const base = 'font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-white/40 p-[calc(var(--nx-spacing-base)*4)] self-start';
+  const base = `font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-text/40 p-[calc(${spacing.base}*4)] self-start focus:outline-none focus:ring-[calc(${spacing.base}*2)] focus:ring-primary focus:ring-offset-[calc(${spacing.base}*2)]`;
   return (
-    <div role="group" aria-label={ariaLabel} className={`${base} ${className}`} {...props} />
+    <div role="group" aria-label={ariaLabel} tabIndex={0} className={`${base} ${className}`} {...props} />
   );
 }

--- a/packages/ui/src/NxButton.tsx
+++ b/packages/ui/src/NxButton.tsx
@@ -1,11 +1,12 @@
 import type { ButtonHTMLAttributes } from 'react';
+import { spacing } from './tokens.js';
 
 export type NxButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   variant?: 'primary' | 'secondary';
 };
 
 export function NxButton({ variant = 'primary', className = '', ...props }: NxButtonProps) {
-  const base = 'font-sans inline-flex items-center justify-center rounded-xl px-[calc(var(--nx-spacing-base)*4)] py-[calc(var(--nx-spacing-base)*2)] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2';
+  const base = `font-sans inline-flex items-center justify-center rounded-xl px-[calc(${spacing.base}*4)] py-[calc(${spacing.base}*2)] focus:outline-none focus:ring-[calc(${spacing.base}*2)] focus:ring-primary focus:ring-offset-[calc(${spacing.base}*2)]`;
   const variants: Record<'primary' | 'secondary', string> = {
     primary: 'bg-primary text-surface',
     secondary: 'bg-surface text-primary border border-primary'

--- a/packages/ui/src/NxChip.tsx
+++ b/packages/ui/src/NxChip.tsx
@@ -1,11 +1,12 @@
 import type { HTMLAttributes } from 'react';
+import { spacing } from './tokens.js';
 
 export type NxChipProps = HTMLAttributes<HTMLDivElement> & {
   variant?: 'default' | 'urgent';
 };
 
 export function NxChip({ variant = 'default', className = '', ...props }: NxChipProps) {
-  const base = 'font-sans inline-flex items-center rounded-2xl px-[calc(var(--nx-spacing-base)*2)] py-[var(--nx-spacing-base)] focus:outline-none focus:ring-2 focus:ring-primary';
+  const base = `font-sans inline-flex items-center rounded-2xl px-[calc(${spacing.base}*2)] py-[${spacing.base}] focus:outline-none focus:ring-[calc(${spacing.base}*2)] focus:ring-primary focus:ring-offset-[calc(${spacing.base}*2)]`;
   const variants: Record<'default' | 'urgent', string> = {
     default: 'bg-surface text-text border border-primary',
     urgent: 'bg-primary text-surface'

--- a/packages/ui/src/NxUserBubble.tsx
+++ b/packages/ui/src/NxUserBubble.tsx
@@ -1,12 +1,13 @@
 import type { HTMLAttributes } from 'react';
+import { spacing } from './tokens.js';
 
 export interface NxBubbleProps extends HTMLAttributes<HTMLDivElement> {
   ariaLabel: string;
 }
 
 export function NxUserBubble({ ariaLabel, className = '', ...props }: NxBubbleProps) {
-  const base = 'font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-white/40 p-[calc(var(--nx-spacing-base)*4)] self-end';
+  const base = `font-sans max-w-[75%] rounded-2xl bg-surface/60 text-text backdrop-blur-[14px] shadow-glass border border-text/40 p-[calc(${spacing.base}*4)] self-end focus:outline-none focus:ring-[calc(${spacing.base}*2)] focus:ring-primary focus:ring-offset-[calc(${spacing.base}*2)]`;
   return (
-    <div role="group" aria-label={ariaLabel} className={`${base} ${className}`} {...props} />
+    <div role="group" aria-label={ariaLabel} tabIndex={0} className={`${base} ${className}`} {...props} />
   );
 }


### PR DESCRIPTION
## Summary
- replace hardcoded spacings/ring sizes in Nx components with token-based values
- add accessible focus styles and group semantics to chat bubbles

## Testing
- `npm run -w packages/ui build`

------
https://chatgpt.com/codex/tasks/task_e_68b1ec8319cc832eadfdd8ca98a0bbf6