### PR TITLE
feat(main-ui): load Inter and IBM Plex Sans fonts

### DIFF
--- a/apps/main-ui/README.md
+++ b/apps/main-ui/README.md
@@ -21,6 +21,21 @@ module.exports = {
 };
 ```
 
+## Fuentes
+
+Las tipografías **Inter** e **IBM Plex Sans** se descargan desde Google Fonts mediante las etiquetas añadidas en `index.html`:
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=IBM+Plex+Sans:wght@400;600&display=swap" rel="stylesheet">
+```
+
+<!-- Ejemplo para alojar las fuentes localmente:
+<link rel="stylesheet" href="/fonts/inter.css">
+<link rel="stylesheet" href="/fonts/ibm-plex-sans.css">
+-->
+
 ## Desarrollo
 
 ```bash

--- a/apps/main-ui/index.html
+++ b/apps/main-ui/index.html
@@ -2,6 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=IBM+Plex+Sans:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>


### PR DESCRIPTION
## Summary
- preconnect and load Inter + IBM Plex Sans from Google Fonts in the main UI
- document fonts and provide commented self-host snippet

## Testing
- `npm run -w apps/main-ui build`
- `npx -w apps/main-ui tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b1f02d9b44832ea6097f4c18094f2a