### PR TITLE
feat(main-ui): handle error and offline states

### DIFF
--- a/apps/main-ui/README.md
+++ b/apps/main-ui/README.md
@@ -44,10 +44,14 @@ npm run -w apps/main-ui dev
 
 ## Estados de depuración
 
-Agrega `?state=empty` o `?state=loading` al URL para forzar estados.
+Agrega `?state=empty`, `?state=loading`, `?state=error` o `?state=offline` al URL para forzar estados.
 
 - `?state=empty` renderiza un placeholder con `role="status"`.
 - `?state=loading` muestra skeletons con glass y `aria-busy="true"`.
+- `?state=error` muestra un banner de error con botón **Reintentar**.
+- `?state=offline` fuerza el aviso de sin conexión.
+
+Para simular offline en el navegador usa DevTools → pestaña Network y selecciona **Offline**.
 
 Revisar copy claro, contraste y que la navegación con tab mantenga foco visible en botones e inputs.
 

--- a/apps/main-ui/src/App.tsx
+++ b/apps/main-ui/src/App.tsx
@@ -1,6 +1,9 @@
-import type { FormEvent } from 'react';
-import { useMemo } from 'react';
+import type { FormEvent, ReactNode } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { NxAssistantBubble, NxButton, NxChip, NxUserBubble } from '@nexusg/ui';
+import ErrorBanner from './components/ErrorBanner';
+import OfflineNotice from './components/OfflineNotice';
+import FirstVictoryBanner from './components/FirstVictoryBanner';
 
 export default function App() {
   const handleSubmit = (e: FormEvent) => {
@@ -15,6 +18,27 @@ export default function App() {
     }
   }, []);
 
+  const [isOffline, setIsOffline] = useState(false);
+
+  useEffect(() => {
+    const update = () => {
+      try {
+        setIsOffline(!navigator.onLine);
+      } catch {
+        setIsOffline(false);
+      }
+    };
+    update();
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, []);
+
+  const isError = state === 'error';
+  const offline = state === 'offline' || isOffline;
   const isLoading = state === 'loading';
 
   let content;
@@ -49,10 +73,16 @@ export default function App() {
     );
   }
 
+  let banner: ReactNode = null;
+  if (isError) banner = <ErrorBanner />;
+  else if (offline) banner = <OfflineNotice />;
+  else banner = <FirstVictoryBanner />;
+
   return (
     <div className="flex h-screen text-text">
       <aside className="w-56 bg-surface border-r border-primary/10 p-4">Sidebar</aside>
       <main className="flex flex-1 flex-col" aria-busy={isLoading}>
+        {banner}
         {content}
         <form
           onSubmit={handleSubmit}

--- a/apps/main-ui/src/components/ErrorBanner.tsx
+++ b/apps/main-ui/src/components/ErrorBanner.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useRef } from 'react';
+import { NxButton } from '@nexusg/ui';
+
+export default function ErrorBanner() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const onRetry = () => {
+    console.log('retry');
+  };
+
+  return (
+    <div className="sticky top-0 z-10 mb-4">
+      <div
+        ref={ref}
+        role="alert"
+        aria-live="assertive"
+        tabIndex={-1}
+        className="bg-surface backdrop-blur-[14px] rounded-2xl shadow-glass border border-white/40 px-4 py-3 flex items-center justify-between gap-3"
+      >
+        <span>Ocurrió un error.</span>
+        <NxButton onClick={onRetry}>Reintentar</NxButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/main-ui/src/components/OfflineNotice.tsx
+++ b/apps/main-ui/src/components/OfflineNotice.tsx
@@ -1,0 +1,13 @@
+export default function OfflineNotice() {
+  return (
+    <div className="sticky top-0 z-10 mb-4">
+      <div
+        role="status"
+        aria-live="polite"
+        className="bg-surface backdrop-blur-[14px] rounded-2xl shadow-glass border border-white/40 px-4 py-3 text-sm"
+      >
+        Estás sin conexión.
+      </div>
+    </div>
+  );
+}

--- a/apps/main-ui/src/nexusg-ui.d.ts
+++ b/apps/main-ui/src/nexusg-ui.d.ts
@@ -1,0 +1,1 @@
+declare module '@nexusg/ui';


### PR DESCRIPTION
## Summary
- add glass ErrorBanner with assertive alert and retry focus
- show OfflineNotice when navigator goes offline
- document debug query params and offline simulation in README

## Testing
- `npm run -w apps/main-ui build`
- `npx -w apps/main-ui tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68b20614007c832ea8741573b96b7cdd