### PR TITLE
ci: add monorepo build and typecheck workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+      - run: npm install
+      - run: npm run -w packages/ui sync:figma --if-present
+      - run: npm run -w packages/ui build
+      - run: npm run -w apps/main-ui build
+      - run: npx -w packages/ui tsc --noEmit
+      - run: npx -w apps/main-ui tsc --noEmit


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and type-check packages/ui and apps/main-ui

## Testing
- `npm install`
- `npm run -w packages/ui sync:figma --if-present`
- `npm run -w packages/ui build`
- `npm run -w apps/main-ui build`
- `npx -w packages/ui tsc --noEmit`
- `npx -w apps/main-ui tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b20c061c90832e898443e4328efae8