### PR TITLE
feat: add smoke test for UI kit

### DIFF
--- a/apps/main-ui/src/App.tsx
+++ b/apps/main-ui/src/App.tsx
@@ -11,13 +11,15 @@ export default function App() {
     e.preventDefault();
   };
 
-  const state = useMemo(() => {
+  const params = useMemo(() => {
     try {
-      return new URLSearchParams(window.location.search).get('state');
+      return new URLSearchParams(window.location.search);
     } catch {
-      return null;
+      return new URLSearchParams();
     }
   }, []);
+  const state = params.get('state');
+  const smoke = params.get('smoke') === '1';
 
   const [isOffline, setIsOffline] = useState(false);
 
@@ -85,18 +87,15 @@ export default function App() {
       <main className="flex flex-1 flex-col" aria-busy={isLoading}>
         {banner}
 
-        {/* --- SMOKE UI (temporal) --- */}
-        <div className="p-4 space-y-4">
-          {/* Bloque rojo (utilidad estándar Tailwind v3) */}
-          <div className="h-10 w-full bg-red-500 rounded-2xl" />
+        {smoke && (
+          <div className="p-4 space-y-4">
+            <div className="bg-red-500 rounded-2xl p-4 text-white">Tailwind v3 OK</div>
 
-          {/* Tarjeta glass (tokens + preset NexusG) */}
-          <div className="rounded-2xl border border-white/40 bg-surface/60 shadow-glass backdrop-blur-[14px] p-4">
-            <p className="text-sm text-text">Glass OK — tokens & preset activos</p>
-            <button className="px-3 py-2 rounded-xl bg-primary/10 text-text">Chip</button>
+            <div className="rounded-2xl border border-white/40 bg-white/60 shadow-glass backdrop-blur-[14px] p-4">
+              <p className="text-sm text-text">Glass OK — tokens & preset activos</p>
+            </div>
           </div>
-        </div>
-        {/* --- /SMOKE UI --- */}
+        )}
 
         {content}
 

--- a/apps/main-ui/src/components/FirstVictoryBanner.tsx
+++ b/apps/main-ui/src/components/FirstVictoryBanner.tsx
@@ -10,7 +10,9 @@ export default function FirstVictoryBanner({ onOpenSummary }: Props) {
   useEffect(() => {
     try {
       const params = new URLSearchParams(window.location.search);
-      const debug = params.get('state') === 'firstVictory';
+      const debug =
+        params.get('banner') === 'force' ||
+        params.get('state') === 'firstVictory';
       const onboardingDone = localStorage.getItem('nx.onboarding.done') === '1';
       const dismissed = localStorage.getItem('nx.fv.dismissed') === '1';
       if (debug || (onboardingDone && !dismissed)) setVisible(true);

--- a/apps/main-ui/src/index.css
+++ b/apps/main-ui/src/index.css
@@ -1,4 +1,4 @@
-@import '@nexusg/ui/dist/styles.css';
+@import '../../packages/ui/dist/styles.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/main-ui/tsconfig.json
+++ b/apps/main-ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",

--- a/docs/QA_UI_Fase4.md
+++ b/docs/QA_UI_Fase4.md
@@ -1,0 +1,10 @@
+# QA UI Fase 4
+
+Checklist visual para validar la integración del UI kit y Tailwind v3 en `apps/main-ui`.
+
+- [ ] Tipografías **Inter** e **IBM Plex Sans** cargadas correctamente.
+- [ ] Tokens (colores, radios, spacing) reflejados en la UI (chips, botones, burbujas).
+- [ ] Glass visible (`backdrop-blur-[14px]`, `bg-white/60`, `border-white/40`, `shadow-glass`).
+- [ ] Navegación por teclado con foco visible en **NxButton** y **NxChip**.
+- [ ] Estados `Empty`, `Loading`, `Error`, `Offline` y banner forzado OK (`?state=...`, `?banner=force`).
+- [ ] Smoke test accesible en `?smoke=1` muestra la caja roja y tarjeta glass.


### PR DESCRIPTION
## Summary
- wire smoke test via `?smoke=1` with Tailwind v3 utilities and glass card
- import UI kit styles from local workspace and support `banner=force`
- add QA checklist for UI Fase 4

## Testing
- `npm run -w packages/ui build`
- `npm run -w apps/main-ui build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e9f08278832ea5e838ab473b7394